### PR TITLE
Cleaned up tutorial 101

### DIFF
--- a/tutorial-101/acquia-pipelines.yml
+++ b/tutorial-101/acquia-pipelines.yml
@@ -5,6 +5,6 @@ events:
       - hello:
           type: script
           script:
-            - #Try to create a docroot directory which Acquia Cloud expects to serve from. If the docroot directory already existis you will get an error in your log.
+            # Try to create a docroot directory which Acquia Cloud expects to serve from. If the docroot directory already existis you will get an error in your log.
             - mkdir docroot
             - echo "Hello, Pipelines!" > docroot/index.html


### PR DESCRIPTION
If you try to run this acquia-pipelines.yml, Pipelines will throw this error:

> Failed to parse the build file. Build file parse error: For event &quot;build&quot; step &quot;hello&quot;, every script attribute has to be a string. See https:&#47;&#47;docs.acquia.com&#47;pipelines&#47;yaml for more information on pipelines yaml formatting.

I think it's due to the comment string.