### PR TITLE
Move pipelines-deploy outside the build event

### DIFF
--- a/tutorial-701/acquia-pipelines.yaml
+++ b/tutorial-701/acquia-pipelines.yaml
@@ -9,6 +9,8 @@ events:
             - touch docroot/index.html
             - echo "Pipelines examples 701. You successfully deployed your build to an ODE" > docroot/index.html
 
+  post-deploy:
+    steps:
       # Deploy the build artifact to a Cloud on-demand environment.
       - deploy:
           script:


### PR DESCRIPTION
I'm not sure I got the syntax right.  The proposed change is moving pipelines-deploy outside the build event per https://support.acquia.com/hc/en-us/articles/360019858674 

Since pipelines-deploy within build now fail.